### PR TITLE
Enhancement: Display ad-hoc history.

### DIFF
--- a/client/job.go
+++ b/client/job.go
@@ -49,13 +49,9 @@ func ListJobExecutions(driver *core.Driver, job *scheduler.Job) ([]*scheduler.Ex
 
 	executions := data.Resources
 
-	// Apparently, we only care about *scheduled* executions, not exeuctions
-	// from ad-hoc job runs.
 	scheduled := make([]*scheduler.Execution, 0)
 	for _, execution := range executions {
-		if !execution.ScheduledTime.IsZero() {
-			scheduled = append(scheduled, execution)
-		}
+		scheduled = append(scheduled, execution)
 	}
 
 	sort.Sort(byExecutionStart(scheduled))

--- a/commands/call-history.go
+++ b/commands/call-history.go
@@ -34,7 +34,7 @@ func CallHistory(services *core.Services, args []string) {
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf call-history CALL-NAME [OPTIONS]")
+		fmt.Println("cf call-history [OPTIONS] CALL-NAME")
 		return
 	}
 

--- a/commands/call-history.go
+++ b/commands/call-history.go
@@ -16,25 +16,25 @@ func CallHistory(services *core.Services, args []string) {
 	filterOutput := "scheduled"
 
 	flags := pflag.NewFlagSet("call-history", pflag.ExitOnError)
-	flags.FuncP("display","d", "display scheduled, manual or complete execution histories", func(value string) error {
+	flags.FuncP("show", "s", "display scheduled, manual or complete call execution history", func(value string) error {
 		if strings.HasPrefix("scheduled", value) {
-			filterOutput="scheduled"
+			filterOutput = "scheduled"
 			return nil
 		} else if strings.HasPrefix("manual", value) {
 			filterOutput = "manual"
 			return nil
 		} else if strings.HasPrefix("all", value) {
-			filterOutput = "all"
+			filterOutput = "complete"
 			return nil
 		} else {
-			return errors.New("The display parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
+			return errors.New("The show parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
 		}
 	})
 	flags.Parse(args)
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf call-history CALL-NAME")
+		fmt.Println("cf call-history CALL-NAME [OPTIONS]")
 		return
 	}
 
@@ -65,15 +65,30 @@ func callHistory(services *core.Services, filterOutput string, args []string) er
 	}
 
 	executions, _ := client.ListCallExecutions(services.Client, call)
-	count := len(executions)
-	if count == 0 {
-		fmt.Printf("No executions for call %s.\n", name)
-		return nil
+	totalCount := len(executions)
+	var manualCount, scheduledCount int
+
+	filterCount := func() int {
+		switch filterOutput {
+		case "scheduled":
+			return scheduledCount
+		case "manual":
+			return manualCount
+		}
+		return totalCount
 	}
 
-	fmt.Println("1 -", count, "of", count, "Total Results")
+	filterDisplayName := func() string {
+		switch filterOutput {
+		case "scheduled":
+			return filterOutput
+		case "manual":
+			return "ad hoc"
+		}
+		return ""
+	}
 
-	output := core.NewTable().Add(
+	table := core.NewTable().Add(
 		"Execution GUID",
 		"Execution State",
 		"Scheduled Time",
@@ -83,16 +98,19 @@ func callHistory(services *core.Services, filterOutput string, args []string) er
 	)
 
 	for _, execution := range executions {
+
 		var scheduledTime string
 
 		if execution.ScheduledTime.IsZero() {
 			scheduledTime = "manual"
+			manualCount++
 		} else {
-			scheduledTime =execution.ScheduledTime.String()
+			scheduledTime = execution.ScheduledTime.String()
+			scheduledCount++
 		}
 
-		if filterOutput == "all" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
-			output.Add(
+		if filterOutput == "complete" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
+			table.Add(
 				execution.GUID,
 				execution.State,
 				scheduledTime,
@@ -103,7 +121,22 @@ func callHistory(services *core.Services, filterOutput string, args []string) er
 		}
 	}
 
-	output.Print()
+	if filterCount() == 0 {
+		fmt.Printf("No%s executions for call %s\n", core.AddSpace(filterDisplayName()), name)
+		return nil
+	}
+
+	makeExecutionPlural := func(v int) string {
+		s := "execution"
+		if v != 0 {
+			s += "s"
+		}
+		return s
+	}
+
+	fmt.Printf("1 - %v out of %v call %s\n", filterCount(), totalCount, makeExecutionPlural(totalCount))
+
+	table.Print()
 
 	return nil
 }

--- a/commands/call-history.go
+++ b/commands/call-history.go
@@ -1,7 +1,11 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
 
 	"github.com/cloudfoundry-community/ocf-scheduler-cf-plugin/client"
 	"github.com/cloudfoundry-community/ocf-scheduler-cf-plugin/core"
@@ -9,12 +13,32 @@ import (
 
 // cf call-history CALL-NAME
 func CallHistory(services *core.Services, args []string) {
+	filterOutput := "scheduled"
+
+	flags := pflag.NewFlagSet("call-history", pflag.ExitOnError)
+	flags.FuncP("display","d", "display scheduled, manual or complete execution histories", func(value string) error {
+		if strings.HasPrefix("scheduled", value) {
+			filterOutput="scheduled"
+			return nil
+		} else if strings.HasPrefix("manual", value) {
+			filterOutput = "manual"
+			return nil
+		} else if strings.HasPrefix("all", value) {
+			filterOutput = "all"
+			return nil
+		} else {
+			return errors.New("The display parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
+		}
+	})
+	flags.Parse(args)
+	args = flags.Args()
+
 	if len(args) != 2 {
 		fmt.Println("cf call-history CALL-NAME")
 		return
 	}
 
-	if err := callHistory(services, args); err != nil {
+	if err := callHistory(services, filterOutput, args); err != nil {
 		fmt.Println("Error:", err.Error())
 		return
 	}
@@ -22,7 +46,7 @@ func CallHistory(services *core.Services, args []string) {
 	fmt.Println("OK")
 }
 
-func callHistory(services *core.Services, args []string) error {
+func callHistory(services *core.Services, filterOutput string, args []string) error {
 	space, err := core.MySpace(services)
 	if err != nil {
 		return fmt.Errorf("Could not get current space.")
@@ -35,7 +59,7 @@ func callHistory(services *core.Services, args []string) error {
 		return fmt.Errorf("Could not find call named %s in space %s.\n", name, space.Name)
 	}
 
-	err = core.PrintActionInProgress(services, "Getting scheduled call history for %s", name)
+	err = core.PrintActionInProgress(services, "Getting call history for %s", name)
 	if err != nil {
 		return err
 	}
@@ -59,14 +83,24 @@ func callHistory(services *core.Services, args []string) error {
 	)
 
 	for _, execution := range executions {
-		output.Add(
-			execution.GUID,
-			execution.State,
-			execution.ScheduledTime.String(),
-			execution.ExecutionStartTime.String(),
-			execution.ExecutionEndTime.String(),
-			execution.Message,
-		)
+		var scheduledTime string
+
+		if execution.ScheduledTime.IsZero() {
+			scheduledTime = "manual"
+		} else {
+			scheduledTime =execution.ScheduledTime.String()
+		}
+
+		if filterOutput == "all" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
+			output.Add(
+				execution.GUID,
+				execution.State,
+				scheduledTime,
+				execution.ExecutionStartTime.String(),
+				execution.ExecutionEndTime.String(),
+				execution.Message,
+			)
+		}
 	}
 
 	output.Print()

--- a/commands/create-job.go
+++ b/commands/create-job.go
@@ -43,7 +43,7 @@ func CreateJob(services *core.Services, args []string) {
 	}
 
 	if len(args) != 4 {
-		fmt.Println("cf create-job APP-NAME JOB-NAME COMMAND [OPTIONS]")
+		fmt.Println("cf create-job [OPTIONS] APP-NAME JOB-NAME COMMAND")
 		return
 	}
 

--- a/commands/delete-call-schedule.go
+++ b/commands/delete-call-schedule.go
@@ -22,7 +22,7 @@ func DeleteCallSchedule(services *core.Services, args []string) {
 	args = flags.Args()
 
 	if len(args) != 3 {
-		fmt.Println("cf delete-call-schedule CALL-NAME SCHEDULE-GUID [OPTIONS]")
+		fmt.Println("cf delete-call-schedule [OPTIONS] CALL-NAME SCHEDULE-GUID")
 		return
 	}
 

--- a/commands/delete-call.go
+++ b/commands/delete-call.go
@@ -22,7 +22,7 @@ func DeleteCall(services *core.Services, args []string) {
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf delete-call CALL-NAME [OPTIONS]")
+		fmt.Println("cf delete-call [OPTIONS] CALL-NAME")
 		return
 	}
 

--- a/commands/delete-job-schedule.go
+++ b/commands/delete-job-schedule.go
@@ -22,7 +22,7 @@ func DeleteJobSchedule(services *core.Services, args []string) {
 
 	args = flags.Args()
 	if len(args) != 3 {
-		fmt.Println("cf delete-job-schedule JOB-NAME SCHEDULE-GUID [OPTIONS]")
+		fmt.Println("cf delete-job-schedule [OPTIONS] JOB-NAME SCHEDULE-GUID")
 		return
 	}
 

--- a/commands/delete-job.go
+++ b/commands/delete-job.go
@@ -22,7 +22,7 @@ func DeleteJob(services *core.Services, args []string) {
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf delete-job JOB-NAME [OPTIONS]")
+		fmt.Println("cf delete-job [OPTIONS] JOB-NAME")
 		return
 	}
 

--- a/commands/job-history.go
+++ b/commands/job-history.go
@@ -16,25 +16,25 @@ func JobHistory(services *core.Services, args []string) {
 	filterOutput := "scheduled"
 
 	flags := pflag.NewFlagSet("job-history", pflag.ExitOnError)
-	flags.FuncP("display","d", "display scheduled, manual or complete execution histories", func(value string) error {
+	flags.FuncP("show", "s", "display scheduled, manual or complete job execution history", func(value string) error {
 		if strings.HasPrefix("scheduled", value) {
-			filterOutput="scheduled"
+			filterOutput = "scheduled"
 			return nil
 		} else if strings.HasPrefix("manual", value) {
 			filterOutput = "manual"
 			return nil
 		} else if strings.HasPrefix("all", value) {
-			filterOutput = "all"
+			filterOutput = "complete"
 			return nil
 		} else {
-			return errors.New("The display parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
+			return errors.New("The show parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
 		}
 	})
 	flags.Parse(args)
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf job-history JOB-NAME")
+		fmt.Println("cf job-history JOB-NAME [OPTIONS]")
 		return
 	}
 
@@ -65,13 +65,28 @@ func jobHistory(services *core.Services, filterOutput string, args []string) err
 	}
 
 	executions, _ := client.ListJobExecutions(services.Client, job)
-	count := len(executions)
-	if count == 0 {
-		fmt.Printf("No executions for job %s.\n", name)
-		return nil
+	totalCount := len(executions)
+	var manualCount, scheduledCount int
+
+	filterCount := func() int {
+		switch filterOutput {
+		case "scheduled":
+			return scheduledCount
+		case "manual":
+			return manualCount
+		}
+		return totalCount
 	}
 
-	fmt.Println("1 -", count, "of", count, "Total Results")
+	filterDisplayName := func() string {
+		switch filterOutput {
+		case "scheduled":
+			return filterOutput
+		case "manual":
+			return "ad hoc"
+		}
+		return ""
+	}
 
 	table := core.NewTable().Add(
 		"Execution GUID",
@@ -88,11 +103,13 @@ func jobHistory(services *core.Services, filterOutput string, args []string) err
 
 		if execution.ScheduledTime.IsZero() {
 			scheduledTime = "manual"
+			manualCount++
 		} else {
-			scheduledTime =execution.ScheduledTime.String()
+			scheduledTime = execution.ScheduledTime.String()
+			scheduledCount++
 		}
 
-		if filterOutput == "all" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
+		if filterOutput == "complete" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
 			table.Add(
 				execution.GUID,
 				execution.State,
@@ -103,6 +120,21 @@ func jobHistory(services *core.Services, filterOutput string, args []string) err
 			)
 		}
 	}
+
+	if filterCount() == 0 {
+		fmt.Printf("No%s executions for job %s\n", core.AddSpace(filterDisplayName()), name)
+		return nil
+	}
+
+	makeExecutionPlural := func(v int) string {
+		s := "execution"
+		if v != 0 {
+			s += "s"
+		}
+		return s
+	}
+
+	fmt.Printf("1 - %v out of %v job %s\n", filterCount(), totalCount, makeExecutionPlural(totalCount))
 
 	table.Print()
 	return nil

--- a/commands/job-history.go
+++ b/commands/job-history.go
@@ -1,7 +1,11 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
 
 	"github.com/cloudfoundry-community/ocf-scheduler-cf-plugin/client"
 	"github.com/cloudfoundry-community/ocf-scheduler-cf-plugin/core"
@@ -9,12 +13,32 @@ import (
 
 // cf job-history JOB-NAME
 func JobHistory(services *core.Services, args []string) {
+	filterOutput := "scheduled"
+
+	flags := pflag.NewFlagSet("job-history", pflag.ContinueOnError)
+	flags.FuncP("display","d", "display scheduled, manual or complete execution histories", func(value string) error {
+		if strings.HasPrefix("scheduled", value) {
+			filterOutput="scheduled"
+			return nil
+		} else if strings.HasPrefix("manual", value) {
+			filterOutput = "manual"
+			return nil
+		} else if strings.HasPrefix("all", value) {
+			filterOutput = "all"
+			return nil
+		} else {
+			return errors.New("The display parameter value must be a prefix of the words, scheduled, manual or all.")
+		}
+	})
+	flags.Parse(args)
+	args = flags.Args()
+
 	if len(args) != 2 {
 		fmt.Println("cf job-history JOB-NAME")
 		return
 	}
 
-	if err := jobHistory(services, args); err != nil {
+	if err := jobHistory(services, filterOutput, args); err != nil {
 		fmt.Println("Error:", err.Error())
 		return
 	}
@@ -22,7 +46,7 @@ func JobHistory(services *core.Services, args []string) {
 	fmt.Println("OK")
 }
 
-func jobHistory(services *core.Services, args []string) error {
+func jobHistory(services *core.Services, filterOutput string, args []string) error {
 	space, err := core.MySpace(services)
 	if err != nil {
 		return fmt.Errorf("Could not get current space.")
@@ -59,14 +83,25 @@ func jobHistory(services *core.Services, args []string) error {
 	)
 
 	for _, execution := range executions {
-		table.Add(
-			execution.GUID,
-			execution.State,
-			execution.ScheduledTime.String(),
-			execution.ExecutionStartTime.String(),
-			execution.ExecutionEndTime.String(),
-			execution.Message,
-		)
+
+		var scheduledTime string
+
+		if execution.ScheduledTime.IsZero() {
+			scheduledTime = "manual"
+		} else {
+			scheduledTime =execution.ScheduledTime.String()
+		}
+
+		if filterOutput == "all" || filterOutput == scheduledTime || (filterOutput == "scheduled" && scheduledTime != "manual") {
+			table.Add(
+				execution.GUID,
+				execution.State,
+				scheduledTime,
+				execution.ExecutionStartTime.String(),
+				execution.ExecutionEndTime.String(),
+				execution.Message,
+			)
+		}
 	}
 
 	table.Print()

--- a/commands/job-history.go
+++ b/commands/job-history.go
@@ -15,7 +15,7 @@ import (
 func JobHistory(services *core.Services, args []string) {
 	filterOutput := "scheduled"
 
-	flags := pflag.NewFlagSet("job-history", pflag.ContinueOnError)
+	flags := pflag.NewFlagSet("job-history", pflag.ExitOnError)
 	flags.FuncP("display","d", "display scheduled, manual or complete execution histories", func(value string) error {
 		if strings.HasPrefix("scheduled", value) {
 			filterOutput="scheduled"
@@ -27,7 +27,7 @@ func JobHistory(services *core.Services, args []string) {
 			filterOutput = "all"
 			return nil
 		} else {
-			return errors.New("The display parameter value must be a prefix of the words, scheduled, manual or all.")
+			return errors.New("The display parameter value must be a prefix of one of theses words, \"scheduled\", \"manual\" or \"all\".")
 		}
 	})
 	flags.Parse(args)
@@ -59,7 +59,7 @@ func jobHistory(services *core.Services, filterOutput string, args []string) err
 		return fmt.Errorf("Could not find job named %s in space %s.\n", name, space.Name)
 	}
 
-	err = core.PrintActionInProgress(services, "Getting scheduled job history for %s", name)
+	err = core.PrintActionInProgress(services, "Getting job history for %s", name)
 	if err != nil {
 		return err
 	}

--- a/commands/job-history.go
+++ b/commands/job-history.go
@@ -34,7 +34,8 @@ func JobHistory(services *core.Services, args []string) {
 	args = flags.Args()
 
 	if len(args) != 2 {
-		fmt.Println("cf job-history JOB-NAME [OPTIONS]")
+		fmt.Println("cf job-history [OPTIONS] JOB-NAME")
+		pflag.Usage()
 		return
 	}
 

--- a/commands/schedule-job.go
+++ b/commands/schedule-job.go
@@ -32,7 +32,6 @@ func ScheduleJob(services *core.Services, args []string) {
 	schedule, err := client.ScheduleJob(services.Client, job, cronExpression)
 	if err != nil {
 		fmt.Printf("Could not schedule job %s with the expression %s.\n", name, cronExpression)
-		fmt.Printf("Error: %+v\n", err )
 		return
 	}
 

--- a/commands/schedule-job.go
+++ b/commands/schedule-job.go
@@ -32,6 +32,7 @@ func ScheduleJob(services *core.Services, args []string) {
 	schedule, err := client.ScheduleJob(services.Client, job, cronExpression)
 	if err != nil {
 		fmt.Printf("Could not schedule job %s with the expression %s.\n", name, cronExpression)
+		fmt.Printf("Error: %+v\n", err )
 		return
 	}
 

--- a/core/util.go
+++ b/core/util.go
@@ -119,6 +119,14 @@ func PrintActionInProgress(services *Services, message string, args ...interface
 	return nil
 }
 
+// function used to avoid double spaces where the string value can be empty
+func AddSpace(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+	return " " + s
+}
+
 type Table struct {
 	rows   []string
 	writer *tabwriter.Writer
@@ -147,5 +155,5 @@ func (t *Table) Print() {
 }
 
 func (t *Table) Count() int {
-	return len(t.rows) 
+	return len(t.rows)
 }

--- a/core/util.go
+++ b/core/util.go
@@ -145,3 +145,7 @@ func (t *Table) Print() {
 	fmt.Fprintf(t.writer, "%s\n", strings.Join(t.rows, "\n"))
 	t.writer.Flush()
 }
+
+func (t *Table) Count() int {
+	return len(t.rows) 
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ess/hype v1.1.5
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.10
 	k8s.io/apimachinery v0.32.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20171017070213-362f9845770f h1:FQZgA673t
 github.com/sabhiram/go-gitignore v0.0.0-20171017070213-362f9845770f/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/square/certstrap v1.3.0 h1:N9P0ZRA+DjT8pq5fGDj0z3FjafRKnBDypP0QHpMlaAk=
 github.com/square/certstrap v1.3.0/go.mod h1:wGZo9eE1B7WX2GKBn0htJ+B3OuRl2UsdCFySNooy9hU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -46,11 +46,11 @@ var ui terminal.UI
 
 func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
-		Name:    "OCFScheduler",
+		Name: "OCFScheduler",
 		Version: plugin.VersionType{
 			Major: getVersion("Major", SemVerMajor),
 			Minor: getVersion("Minor", SemVerMinor),
-			Build: getVersion("Patch",SemVerPatch),
+			Build: getVersion("Patch", SemVerPatch),
 		},
 		Commands: []plugin.Command{
 			{

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "create-job",
 				HelpText: "Creates a job (task) related to an app.",
 				UsageDetails: plugin.Usage{
-					Usage: "create-job:\n\tcf create-job APP-NAME JOB-NAME COMMAND [OPTIONS]\n\nWHERE\n\tAPP-NAME is the name of the cf app environment to execute with\n\tJOB-NAME is the name for this job (task)\n\tCOMMAND is the name of the command to execute within the app environment.\n\nOPTIONS\n\t--disk LIMIT/-k LIMIT set job(task) disk limit (default 1024M)\n\t--memory LIMIT/-m LIMIT set the job(task) memory limit (default 1024M)\n\n\tNOTE: In both of the above options, LIMIT must be specified as an\n\tinteger with an M or G at the end. This suffix is required to\n\tdifferentiate between megabytes and gigabytes (and to avoid parser\n\terrors).\n",
+					Usage: "create-job:\n\tcf create-job [OPTIONS] APP-NAME JOB-NAME COMMAND\n\nWHERE\n\tAPP-NAME is the name of the cf app environment to execute with\n\tJOB-NAME is the name for this job (task)\n\tCOMMAND is the name of the command to execute within the app environment.\n\nOPTIONS\n\t--disk, -k LIMIT set job(task) disk limit (default 1024M)\n\t--memory, -m LIMIT set the job(task) memory limit (default 1024M)\n\n\tNOTE: In both of the above options, LIMIT must be specified as an\n\tinteger with an M or G at the end. This suffix is required to\n\tdifferentiate between megabytes and gigabytes (and to avoid parser\n\terrors).\n",
 				},
 			},
 			{
@@ -99,14 +99,14 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "delete-job",
 				HelpText: "Deletes named job.",
 				UsageDetails: plugin.Usage{
-					Usage: "delete-job:\n\tcf delete-job JOB-NAME [OPTIONS]\n\nWHERE\n\tJOB-NAME is the job (task) name to delete\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
+					Usage: "delete-job:\n\tcf delete-job [OPTIONS] JOB-NAME\n\nWHERE\n\tJOB-NAME is the job (task) name to delete\n\nOPTIONS\n\t--force, -f   Force deletion without confirmation",
 				},
 			},
 			{
 				Name:     "delete-job-schedule",
 				HelpText: "Deletes the job scheduled with the named GUID.",
 				UsageDetails: plugin.Usage{
-					Usage: "delete-job-schedule:\n\tcf delete-call-schedule JOB-NAME SCHEDULE-GUID [OPTIONS]\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
+					Usage: "delete-job-schedule:\n\tcf delete-call-schedule [OPTIONS] JOB-NAME SCHEDULE-GUID\n\nOPTIONS\n\t--force, -f   Force deletion without confirmation",
 				},
 			},
 			{
@@ -155,14 +155,14 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "delete-call",
 				HelpText: "Deletes the named call.",
 				UsageDetails: plugin.Usage{
-					Usage: "delete-call:\n\tcf delete-call CALL-NAME [OPTIONS]\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
+					Usage: "delete-call:\n\tcf delete-call [OPTIONS] CALL-NAME\n\nOPTIONS\n\t--force, -f   Force deletion without confirmation",
 				},
 			},
 			{
 				Name:     "delete-call-schedule",
 				HelpText: "Delete a call scheduled with a given GUID",
 				UsageDetails: plugin.Usage{
-					Usage: "delete-call-schedule:\n\tcf delete-call-schedule CALL-NAME SCHEDULE-GUID [OPTIONS]\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
+					Usage: "delete-call-schedule:\n\tcf delete-call-schedule [OPTIONS] CALL-NAME SCHEDULE-GUID\n\nOPTIONS\n\t--force, -f   Force deletion without confirmation",
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "job-history",
 				HelpText: "Lists execution history for the given job name",
 				UsageDetails: plugin.Usage{
-					Usage: "job-history:\n\tcf job-history JOB-NAME",
+					Usage: "job-history:\n\tcf job-history [OPTIONS] JOB-NAME\n\nWHERE\n\tJOB-NAME is the requested job name for its historical execution data\n\nOPTIONS\n\t--show, -s (scheduled | manual | all)\n\n\tThe show parameter filters job history based on execution type:\n\tscheduled or ad hoc(\"manual\"). The \"all\" parameter shows both\n\texecution types at the same time. The parameter value is prefix-matched,\n\tso you do not need to provide the full value. (default: \"scheduled\")\n",
 				},
 			},
 			{
@@ -106,7 +106,7 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "delete-job-schedule",
 				HelpText: "Deletes the job scheduled with the named GUID.",
 				UsageDetails: plugin.Usage{
-					Usage: "delete-job-schedule:\n\tcf delete-job-schedule JOB-NAME SCHEDULE-GUID [OPTIONS]\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
+					Usage: "delete-job-schedule:\n\tcf delete-call-schedule JOB-NAME SCHEDULE-GUID [OPTIONS]\n\nOPTIONS\n\t--force /-f   Force deletion without confirmation",
 				},
 			},
 			{
@@ -148,7 +148,7 @@ func (c *OCFScheduler) GetMetadata() plugin.PluginMetadata {
 				Name:     "call-history",
 				HelpText: "Shows the execution history for the named call.",
 				UsageDetails: plugin.Usage{
-					Usage: "call-history:\n\tcf call-history CALL-NAME",
+					Usage: "call-history:\n\tcf call-history [OPTIONS] CALL-NAME\n\nWHERE\n\tCALL-NAME is the requested call name for its historical execution data\n\nOPTIONS\n\t--show, -s (scheduled | manual | all)\n\n\tThe show parameter filters call history based on execution type:\n\tscheduled or ad hoc(\"manual\"). The \"all\" parameter shows both\n\texecution types at the same time. The parameter value is prefix-matched,\n\tso you do not need to provide the full value. (default: \"scheduled\")\n",
 				},
 			},
 			{


### PR DESCRIPTION
The history commands only returned the scheduled histories.  It is now possible to retrieve the ad hoc history as well.   The displayed data is chosen by using the --show parameter. 

--show, -s (all | manual | scheduled)

The show value is prefix-matched, so the complete value is not required.